### PR TITLE
Specify Fields in Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ $filerdb
   ->get();
 ```
 
+### Specify fields that come back in response
+
+```
+// Only returns the username field
+$filerdb
+  ->database('dev')
+  ->collection('users')
+  ->get(['username']);
+```
+
 ### Ordering documents by a field
 
 ```

--- a/example/dev.php
+++ b/example/dev.php
@@ -29,8 +29,8 @@ try {
   $data = $filerdb
     ->database('test')
     ->collection('users')
-    ->limit(1, 1)
-    ->get();
+    ->id('5ed1b2957c6d92')
+    ->get(['username']);
 
   print_r($data);
 } catch (Exception $e) {

--- a/src/FilerDB/Core/Libraries/Collection.php
+++ b/src/FilerDB/Core/Libraries/Collection.php
@@ -70,6 +70,8 @@ class Collection {
 
     // Holder for documents that should be returned
     $this->documents = $this->getDocuments();
+
+    $this->response  = $this->documents;
   }
 
   /**
@@ -95,7 +97,18 @@ class Collection {
    * orders, and anything else that chains
    * before it.
    */
-  public function get () {
+  public function get ($fields = false) {
+
+    /**
+     * If the columns parameter is provided,
+     * and is an array.
+     */
+    if (is_array($fields)) {
+      if (count($fields) >= 1) {
+        return $this->pickFieldsFromData($this->response, $fields);
+      }
+    }
+
     return $this->response;
   }
 
@@ -570,6 +583,25 @@ class Collection {
    * Helper methods
    * ==============================
    */
+
+  private function pickFieldsFromData ($data, $fields) {
+
+    print_r($data);
+
+    if (is_array($data)) {
+      foreach ($data as $documentKey => $document) {
+        foreach ($document as $field => $value) {
+          if (!in_array($field, $fields)) unset($data[$documentKey]->{$field});
+        }
+      }
+    } else {
+      foreach ($data as $field => $val) {
+        if (!in_array($field, $fields)) unset($data->{$field});
+      }
+    }
+
+    return $data;
+  }
 
   /**
    * Find a document by it's id in an array


### PR DESCRIPTION
### Description

Allows for the ability to specify the fields you want to come back in the response.

### Example:

```
// Example data

{
    "id": "5ed1b2957c6d9",
    "username": "test",
    "email": "test@test.com",
    "location": {
        "country": "US",
        "state": "CA"
    }
}
```

### Syntax 

```
$filerdb->database('test')->collection('users')->get(['username']);
```

### Response 

```
stdClass Object
(
    [username] => etari3
)
```