### PR TITLE
Structural Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install via composer:
 use FilerDB\Instance;
 
 // Instantiate Database
-$filerdb = new Instance([ 'path' => __DIR__ . '/database/' ]);
+$filerdb = new Instance([ 'root' => __DIR__ . '/database/' ]);
 ```
 
 ### Configuration
@@ -25,15 +25,27 @@ $filerdb = new Instance([ 'path' => __DIR__ . '/database/' ]);
 [
 
   /**
-   * This is the main path for FilerDB.
+   * This is the root path for FilerDB.
    */
-  'path' => __DIR__ . '/database',
+  'root' => false,
 
   /**
-   * If the database path does not exist, try
+   * If the root path does not exist, try
+   * and create it.
+   */
+  'createRootIfNotExist' => false,
+
+  /**
+   * If the database does not exist, try
    * and create it.
    */
   'createDatabaseIfNotExist' => false,
+
+  /**
+   * If the collection does not exist, attempt
+   * to create it.
+   */
+  'createCollectionIfNotExist' => false,
 
   /**
    * If the insert and update logic handles

--- a/example/database/test/users.json
+++ b/example/database/test/users.json
@@ -9,7 +9,7 @@
         "id": "5ed1b2957c6d9"
     },
     {
-        "username": "etari3",
+        "username": "test234",
         "email": "matt@irate.dev",
         "location": {
             "country": "US",
@@ -25,5 +25,13 @@
             "state": "KY"
         },
         "id": "5ed1b2957c6d93"
+    },
+    {
+        "id": "5ed1b2957c6d92",
+        "username": "test234"
+    },
+    {
+        "id": "5ed1b2957c6d92",
+        "username": "test234"
     }
 ]

--- a/example/dev.php
+++ b/example/dev.php
@@ -15,24 +15,15 @@ try {
     'createDatabaseIfNotExist' => true
   ]);
 
-  /**
-   * Example of limiting to 1 response, and
-   * offsetting it.
-   *
-   * limit(1, 1)
-   *
-   * @param Limiter
-   * @param Offset
-   *
-   * Offset is the array key of the response.
-   */
   $data = $filerdb
     ->database('test')
     ->collection('users')
-    ->id('5ed1b2957c6d92')
-    ->get(['username']);
+    ->filter(['id' => '5ed1b2957c6d92'])
+    ->update([
+      'username' => 'test234'
+    ]);
 
-  print_r($data);
+  var_dump($data);
 } catch (Exception $e) {
   echo $e->getMessage() . PHP_EOL;
 }

--- a/example/dev.php
+++ b/example/dev.php
@@ -8,22 +8,23 @@ try {
   $filerdb = new FilerDB\Instance([
 
     // Required
-    'path' => __DIR__ . '/database',
+    'path' => __DIR__ . '/database2',
 
     // Optional configurations
     'includeTimestamps' => false,
-    'createDatabaseIfNotExist' => true
+
+    'database' => 'woot',
+
+    // Configs
+    'createRootIfNotExist' => true,
+    'createDatabaseIfNotExist' => true,
+    'createCollectionIfNotExist' => true
   ]);
 
-  $data = $filerdb
-    ->database('test')
-    ->collection('users')
-    ->filter(['id' => '5ed1b2957c6d92'])
-    ->update([
-      'username' => 'test234'
-    ]);
+  $filerdb->collection('foo')->insert([
+    'testing' => true
+  ]);
 
-  var_dump($data);
 } catch (Exception $e) {
   echo $e->getMessage() . PHP_EOL;
 }

--- a/example/dev.php
+++ b/example/dev.php
@@ -8,11 +8,12 @@ try {
   $filerdb = new FilerDB\Instance([
 
     // Required
-    'path' => __DIR__ . '/database2',
+    'root' => __DIR__ . '/database2',
 
     // Optional configurations
     'includeTimestamps' => false,
 
+    // Specify database
     'database' => 'woot',
 
     // Configs

--- a/src/FilerDB/Core/Helpers/Document.php
+++ b/src/FilerDB/Core/Helpers/Document.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace FilerDB\Core\Helpers;
+
+use FilerDB\Core\Exceptions\FilerDBException;
+
+class Document {
+
+  /**
+   * Check documents to see if the id exists.
+   * @param  array
+   * @param  string
+   * @return boolean
+   */
+  public static function exists ($documents, $id) {
+    if (self::byId($documents, $id) === false) return false;
+    return true;
+  }
+
+  /**
+   * Iterates through an array of documents, and finds
+   * the object that has a specific id. It will then
+   * return an object with the index, and the data
+   * of that document.
+   * @param  array $documents
+   * @param  string $id
+   * @return mixed
+   */
+  public static function byId ($documents, $id = null) {
+    if (is_null($id)) return false;
+
+    // Set the index to false by default
+    $index = false;
+
+    // Set the doc to false by default.
+    $doc = false;
+
+    // Iterate through documents, continue if no match.
+    foreach ($documents as $i => $document) {
+
+      if ($document->id === $id) {
+        $index = $i;
+        $doc = $document;
+      } else {
+        continue;
+      }
+    }
+
+    // If no index was set, return false.
+    if (!$index) return false;
+
+    // Return object with data.
+    return (object) [
+      'index' => $index,
+      'document' => $doc
+    ];
+  }
+}

--- a/src/FilerDB/Core/Libraries/Collection.php
+++ b/src/FilerDB/Core/Libraries/Collection.php
@@ -76,7 +76,7 @@ class Collection {
 
     // Build the collection path
     $this->collectionPath = FileSystem::collectionPath(
-      $this->config->DATABASE_PATH,
+      $this->config->root,
       $this->database,
       $this->collection
     );

--- a/src/FilerDB/Core/Libraries/Collection.php
+++ b/src/FilerDB/Core/Libraries/Collection.php
@@ -48,6 +48,12 @@ class Collection {
   private $response = [];
 
   /**
+   * Holds the path for the collection in the filesystem.
+   * @var string
+   */
+  private $collectionPath = null;
+
+  /**
    * Class constructor
    */
   public function __construct ($config = null, $database, $collection) {
@@ -65,8 +71,15 @@ class Collection {
     // Set the current database
     $this->database = $database;
 
-    // Retrieve the current database.
+    // Retrieve the current collection.
     $this->collection = $collection;
+
+    // Build the collection path
+    $this->collectionPath = FileSystem::collectionPath(
+      $this->config->DATABASE_PATH,
+      $this->database,
+      $this->collection
+    );
 
     // Holder for documents that should be returned
     $this->documents = $this->getDocuments();
@@ -366,7 +379,7 @@ class Collection {
     $json = json_encode($documents, JSON_PRETTY_PRINT);
 
     // Attempt to write file
-    $inserted = FileSystem::writeFile($this->path(), $json);
+    $inserted = FileSystem::writeFile($this->collectionPath, $json);
 
     // If not inserted, throw an error.
     if (!$inserted)
@@ -436,7 +449,7 @@ class Collection {
     $json = json_encode($originalDocuments, JSON_PRETTY_PRINT);
 
     // Attempt to write file
-    $updated = FileSystem::writeFile($this->path(), $json);
+    $updated = FileSystem::writeFile($this->collectionPath, $json);
 
     // If not deleted, throw an error.
     if (!$updated)
@@ -460,7 +473,7 @@ class Collection {
     $json = json_encode($documents, JSON_PRETTY_PRINT);
 
     // Attempt to write file
-    $emptied = FileSystem::writeFile($this->path(), $json);
+    $emptied = FileSystem::writeFile($this->collectionPath, $json);
 
     // If not deleted, throw an error.
     if (!$emptied)
@@ -506,7 +519,7 @@ class Collection {
     $json = json_encode($originalDocuments, JSON_PRETTY_PRINT);
 
     // Attempt to write file
-    $deleted = FileSystem::writeFile($this->path(), $json);
+    $deleted = FileSystem::writeFile($this->collectionPath, $json);
 
     // If not deleted, throw an error.
     if (!$deleted)
@@ -615,7 +628,7 @@ class Collection {
    * an error because the data is malformed.
    */
   private function getDocuments () {
-    $contents = file_get_contents ($this->path());
+    $contents = file_get_contents ($this->collectionPath);
 
     try {
       $contents = json_decode($contents);
@@ -624,18 +637,5 @@ class Collection {
     }
 
     return $contents;
-  }
-
-  /**
-   * Returns a path for the current collection.
-   */
-  private function path () {
-    $path = $this->config->DATABASE_PATH .
-            DIRECTORY_SEPARATOR .
-            $this->database .
-            DIRECTORY_SEPARATOR .
-            $this->collection . '.json';
-
-    return $path;
   }
 }

--- a/src/FilerDB/Core/Libraries/Collection.php
+++ b/src/FilerDB/Core/Libraries/Collection.php
@@ -9,8 +9,8 @@ use FilerDB\Core\Utilities\FileSystem;
 use FilerDB\Core\Utilities\Timestamp;
 use FilerDB\Core\Utilities\Dot;
 
-// Libraries
-use FilerDB\Core\Libraries\Document;
+// Helpers
+use FilerDB\Core\Helpers\Document;
 
 class Collection {
 
@@ -71,6 +71,7 @@ class Collection {
     // Holder for documents that should be returned
     $this->documents = $this->getDocuments();
 
+    // Holder for response that is returned
     $this->response  = $this->documents;
   }
 
@@ -85,7 +86,7 @@ class Collection {
    */
   public function id ($id) {
     $documents = $this->documents;
-    $data = $this->documentById($id, $documents);
+    $data = Document::byId($documents, $id);
     if ($data === false) return false;
     $this->documents = $documents[$data->index];
     $this->response  = $this->documents;
@@ -344,7 +345,7 @@ class Collection {
     $id = (isset($insertData->id) ? $insertData->id : uniqid());
 
     // If the id already set?
-    if ($this->documentById($id, $documents) !== false)
+    if (Document::exists($documents, $id))
       throw new FilerDBException("Document with id:$id already exists");
 
     $insertData->id = $id;
@@ -388,7 +389,7 @@ class Collection {
       // we can assume it's a single document that is being
       // updated.
       if (!is_array($documentsToUpdate)) {
-        $docInfo = $this->documentById($this->documents->id, $originalDocuments);
+        $docInfo = Document::byId($originalDocuments, $this->documents->id);
         $key = $docInfo->index;
 
         // Update all of the keys
@@ -606,35 +607,6 @@ class Collection {
     }
 
     return $data;
-  }
-
-  /**
-   * Find a document by it's id in an array
-   * of documents.
-   *
-   * Returns the index and the document data in
-   * object format.
-   */
-  private function documentById ($id, $documents) {
-    $index = false;
-    $doc = false;
-
-    foreach ($documents as $i => $document) {
-
-      if ($document->id === $id) {
-        $index = $i;
-        $doc = $document;
-      } else {
-        continue;
-      }
-    }
-
-    if (!$index) return false;
-
-    return (object) [
-      'index' => $index,
-      'document' => $doc
-    ];
   }
 
   /**

--- a/src/FilerDB/Core/Libraries/Database.php
+++ b/src/FilerDB/Core/Libraries/Database.php
@@ -44,7 +44,7 @@ class Database {
     $this->database = $database;
 
     // Build the database path
-    $this->databasePath = FileSystem::databasePath($this->config->DATABASE_PATH, $this->database);
+    $this->databasePath = FileSystem::databasePath($this->config->root, $this->database);
   }
 
   /**
@@ -66,7 +66,7 @@ class Database {
 
         // Build the collection path
         $collectionPath = FileSystem::collectionPath(
-          $this->config->DATABASE_PATH,
+          $this->config->root,
           $this->database,
           $collection
         );

--- a/src/FilerDB/Core/Libraries/Database.php
+++ b/src/FilerDB/Core/Libraries/Database.php
@@ -23,6 +23,12 @@ class Database {
   public $database;
 
   /**
+   * Holds the database path in the filesystem
+   * @var string
+   */
+  private $databasePath = null;
+
+  /**
    * Class constructor
    */
   public function __construct ($config = null, $database) {
@@ -36,6 +42,9 @@ class Database {
 
     // Retrieve the current database.
     $this->database = $database;
+
+    // Build the database path
+    $this->databasePath = FileSystem::databasePath($this->config->DATABASE_PATH, $this->database);
   }
 
   /**
@@ -47,8 +56,32 @@ class Database {
    * it auto creates the collection if it doesn't exist.
    */
   public function collection($collection) {
-    if (!$this->collectionExists($collection))
-      throw new FilerDBException('Collection does not exist');
+
+    // If the collection does not exist
+    if (!$this->collectionExists($collection)) {
+
+      // If the collection does not exist, and config says to attempt
+      // to create it, do that here.
+      if ($this->config->createCollectionIfNotExist === true) {
+
+        // Build the collection path
+        $collectionPath = FileSystem::collectionPath(
+          $this->config->DATABASE_PATH,
+          $this->database,
+          $collection
+        );
+
+        // Attempt to create the directory
+        $created = FileSystem::writeFile($collectionPath, json_encode([]));
+
+        // If not created, then a permissions error probably happened.
+        if (!$created)
+          throw new FilerDBException('Path not found, also unable to create database path.');
+
+      } else {
+        throw new FilerDBException("$collection does not exist");
+      }
+    }
 
     return new Collection($this->config, $this->database, $collection);
   }
@@ -64,7 +97,7 @@ class Database {
    * @param string $database
    */
   public function createCollection($collection) {
-    $collectionPath = $this->path() . $collection . '.json';
+    $collectionPath = $this->databasePath . $collection . '.json';
     $exists = $this->collectionExists($collection);
     if ($exists) throw new FilerDBException('Collection already exists');
     $created = FileSystem::writeFile($collectionPath, json_encode([]));
@@ -77,7 +110,7 @@ class Database {
    * @param string $collection
    */
   public function deleteCollection($collection) {
-    $collectionPath = $this->path() . $collection . '.json';
+    $collectionPath = $this->databasePath . $collection . '.json';
     $exists = $this->collectionExists($collection);
     if (!$exists) throw new FilerDBException('Collection does not exist');
     $removed = FileSystem::deleteFile($collectionPath);
@@ -121,22 +154,13 @@ class Database {
    */
   private function retrieveCollections() {
     $result = [];
-    $collections = glob($this->path() . '*.json' , GLOB_BRACE);
+    $collections = glob($this->databasePath . '*.json' , GLOB_BRACE);
 
     foreach ($collections as $collection) {
       $result[] = basename($collection, '.json');
     }
 
     return $result;
-  }
-
-  /**
-   * Builds the path for the database in the file system.
-   * @return string $path
-   */
-  private function path () {
-    $path = $this->config->DATABASE_PATH . DIRECTORY_SEPARATOR . $this->database . DIRECTORY_SEPARATOR;
-    return $path;
   }
 
 }

--- a/src/FilerDB/Core/Libraries/Databases.php
+++ b/src/FilerDB/Core/Libraries/Databases.php
@@ -69,14 +69,14 @@ class Databases {
 
   /**
    * Creates a new directory for the database in
-   * the DATABASE_PATH
+   * the root
    * @param string $database
    */
   public function create($database) {
     $exists = $this->exists($database);
     if ($exists) throw new FilerDBException('Database already exists');
     $created = FileSystem::createDirectory(
-      FileSystem::databasePath($this->config->DATABASE_PATH, $database)
+      FileSystem::databasePath($this->config->root, $database)
     );
     if (!$created) throw new FilerDBException('Database was unable to be created');
     $this->retrieveDatabases();
@@ -85,14 +85,14 @@ class Databases {
 
   /**
    * Delets a directory for the database in
-   * the DATABASE_PATH
+   * the root
    * @param string $database
    */
   public function delete($database) {
     $exists = $this->exists($database);
     if (!$exists) throw new FilerDBException('Database does not exist');
     $removed = FileSystem::removeDirectory(
-      FileSystem::databasePath($this->config->DATABASE_PATH, $database)
+      FileSystem::databasePath($this->config->root, $database)
     );
     if (!$removed) throw new FilerDBException('Database was unable to be deleted');
     $this->retrieveDatabases();
@@ -111,7 +111,7 @@ class Databases {
    */
   private function retrieveDatabases() {
     $result = [];
-    $databases = glob($this->config->DATABASE_PATH . '*' , GLOB_ONLYDIR);
+    $databases = glob($this->config->root . '*' , GLOB_ONLYDIR);
 
     foreach ($databases as $database) {
       $pathParts = explode('/', $database);
@@ -126,7 +126,7 @@ class Databases {
    * @return string $path
    */
   private function path ($database) {
-    $path = $this->config->DATABASE_PATH . DIRECTORY_SEPARATOR . $database . DIRECTORY_SEPARATOR;
+    $path = $this->config->root . DIRECTORY_SEPARATOR . $database . DIRECTORY_SEPARATOR;
     return $path;
   }
 

--- a/src/FilerDB/Core/Libraries/Databases.php
+++ b/src/FilerDB/Core/Libraries/Databases.php
@@ -75,7 +75,9 @@ class Databases {
   public function create($database) {
     $exists = $this->exists($database);
     if ($exists) throw new FilerDBException('Database already exists');
-    $created = FileSystem::createDirectory($this->path($database));
+    $created = FileSystem::createDirectory(
+      FileSystem::databasePath($this->config->DATABASE_PATH, $database)
+    );
     if (!$created) throw new FilerDBException('Database was unable to be created');
     $this->retrieveDatabases();
     return true;
@@ -89,7 +91,9 @@ class Databases {
   public function delete($database) {
     $exists = $this->exists($database);
     if (!$exists) throw new FilerDBException('Database does not exist');
-    $removed = FileSystem::removeDirectory($this->path($database));
+    $removed = FileSystem::removeDirectory(
+      FileSystem::databasePath($this->config->DATABASE_PATH, $database)
+    );
     if (!$removed) throw new FilerDBException('Database was unable to be deleted');
     $this->retrieveDatabases();
     return true;

--- a/src/FilerDB/Core/Libraries/Document.php
+++ b/src/FilerDB/Core/Libraries/Document.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace FilerDB\Core\Libraries;
-
-use FilerDB\Core\Exceptions\FilerDBException;
-
-class Document {
-
-}

--- a/src/FilerDB/Core/Utilities/Backup.php
+++ b/src/FilerDB/Core/Utilities/Backup.php
@@ -37,7 +37,7 @@ class Backup {
     try {
 
       $zipFile
-        ->addDirRecursive($this->config->DATABASE_PATH)
+        ->addDirRecursive($this->config->root)
         ->saveAsFile($output)
         ->close();
 

--- a/src/FilerDB/Core/Utilities/FileSystem.php
+++ b/src/FilerDB/Core/Utilities/FileSystem.php
@@ -6,8 +6,29 @@ use FilerDB\Core\Exceptions\FilerDBException;
 
 class FileSystem {
 
-  public static function databasePath ($path) {
-    return $path . DIRECTORY_SEPARATOR;
+  public static function rootPath ($path) {
+    if (substr($path, -1) !== '/') $path = $path . DIRECTORY_SEPARATOR;
+    return $path;
+  }
+
+  public static function databasePath ($path, $database) {
+    return $path . $database . DIRECTORY_SEPARATOR;
+  }
+
+  /**
+   * Returns collection path for the file system.
+   * @param  string $root
+   * @param  string $database
+   * @param  string $collection
+   * @return string
+   */
+  public static function collectionPath ($root, $database, $collection) {
+    $path = $root .
+            $database .
+            DIRECTORY_SEPARATOR .
+            $collection . '.json';
+
+    return $path;
   }
 
   /**

--- a/src/FilerDB/Instance.php
+++ b/src/FilerDB/Instance.php
@@ -123,7 +123,7 @@ class Instance
   private function _runCoreChecks () {
 
     // Builds the path for the database.
-    $rootPath = FileSystem::rootPath($this->config->DATABASE_PATH);
+    $rootPath = FileSystem::rootPath($this->config->root);
 
     /**
      * If database path does not exist,
@@ -152,7 +152,7 @@ class Instance
    * Initializes the database
    */
   private function _initialize () {
-    if (!$this->config->DATABASE_PATH)
+    if (!$this->config->root)
       throw new FilerDBException("No database path provided.");
 
     $this->databases = new Databases($this->config);
@@ -176,7 +176,7 @@ class Instance
 
         // Get the database path
         $databasePath = FileSystem::databasePath(
-          $this->config->DATABASE_PATH,
+          $this->config->root,
           $database
         );
 
@@ -216,7 +216,7 @@ class Instance
       // to create it, do that here.
       if ($this->config->createCollectionIfNotExist === true) {
         $collectionPath = FileSystem::collectionPath(
-          $this->config->DATABASE_PATH,
+          $this->config->root,
           $this->config->database,
           $collection
         );
@@ -255,7 +255,7 @@ class Instance
 
         // Get the database path
         $databasePath = FileSystem::databasePath(
-          $this->config->DATABASE_PATH,
+          $this->config->root,
           $database
         );
 
@@ -306,10 +306,10 @@ class Instance
 
       foreach ($config as $key => $val) {
 
-        // Make sure path sets DATABASE_PATH for
+        // Make sure path sets root for
         // backwards compatibility.
-        if ($key === 'path' || $key === 'DATABASE_PATH') {
-          $this->set('DATABASE_PATH', FileSystem::rootPath($val));
+        if ($key === 'path' || $key === 'root') {
+          $this->set('root', FileSystem::rootPath($val));
         } else {
           $this->set($key, $val);
         }

--- a/src/FilerDB/Instance.php
+++ b/src/FilerDB/Instance.php
@@ -242,7 +242,9 @@ class Instance
    * to go to.
    */
   public function selectDatabase ($database = null) {
-    $database = $database || $this->config->database;
+    $database = !is_null($database) ? $database : $this->config->database;
+
+    if (!$database) throw new FilerDBException('No database provided');
 
     if (!$this->databases->exists($database)) {
 
@@ -250,8 +252,6 @@ class Instance
        * If set to create when non-existent
        */
       if ($this->config->createDatabaseIfNotExist === true) {
-
-        var_dump($databasePath);
 
         // Get the database path
         $databasePath = FileSystem::databasePath(

--- a/src/FilerDB/Instance.php
+++ b/src/FilerDB/Instance.php
@@ -76,10 +76,22 @@ class Instance
       'path' => false,
 
       /**
+       * If the root path does not exist, try
+       * and create it.
+       */
+      'createRootIfNotExist' => false,
+
+      /**
        * If the database path does not exist, try
        * and create it.
        */
       'createDatabaseIfNotExist' => false,
+
+      /**
+       * If the collection does not exist, attempt
+       * to create it.
+       */
+      'createCollectionIfNotExist' => false,
 
       /**
        * If the insert and update logic handles
@@ -120,7 +132,7 @@ class Instance
     if (!FileSystem::pathExists($databasePath)) {
 
       // Make sure the config var is set to true.
-      if ($this->config->createDatabaseIfNotExist === true) {
+      if ($this->config->createRootIfNotExist === true) {
 
         // Attempt to create the directory
         $created = FileSystem::createDirectory($databasePath);

--- a/src/FilerDB/Instance.php
+++ b/src/FilerDB/Instance.php
@@ -71,9 +71,9 @@ class Instance
     $this->_setInitialConfig([
 
       /**
-       * This is the main path for FilerDB.
+       * This is the root path for FilerDB.
        */
-      'path' => false,
+      'root' => false,
 
       /**
        * If the root path does not exist, try


### PR DESCRIPTION
Will remove duplicate code regarding paths, and will use one source of truth (\Utilities\FileSystem) to determine the paths for root, databases, and collections.

Change DATABASE_PATH to `root` to make more sense now that we support multiple databases.

Added new configuration logic:

- createRootIfNotExist - Tries to create the root directory if it doesn't exist 
- createDatabaseIfNotExist - Tries to create the database directory if it doesn't exist 
- createCollectionIfNotExist - Tries to create the collection if it doesn't exist. 

A LOT of clean up around the code base.